### PR TITLE
Update SyncExample.csproj

### DIFF
--- a/async/async-and-await/cs/SyncExample/SyncExample.csproj
+++ b/async/async-and-await/cs/SyncExample/SyncExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 


### PR DESCRIPTION
The target platform must be set to Windows (usually by including '-windows' in the TargetFramework property) when using Windows Forms or WPF, or referencing projects or packages that do so.

## Summary

Describe your changes here.

Fixes #Issue_Number, dotnet/docs#Issue_Number or dotnet/dotnet-api-docs#Issue_Number (if available)
